### PR TITLE
do not use BASE_URL for webhistory

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHistory(),
   routes: [
     {
       path: '/',


### PR DESCRIPTION
`vue` always added a `static/` to the home url which then caused problems (because routing is done through django, not through the frontend). the reason for this is the `history` parameter in the `router`-setup for vue

see https://router.vuejs.org/api/#Functions-createWebHistory

@AnjaWurli feel free to merge this